### PR TITLE
Fixes #4 - Add support for param encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ```ruby
 
-pod 'RSSwiftNetworking', '~> 1.0.0'
+pod 'RSSwiftNetworking', '~> 1.1.0'
 
 ```
 
@@ -26,7 +26,7 @@ pod 'RSSwiftNetworking', '~> 1.0.0'
 Add the following line to your `Cartfile` and follow the [installation instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 
 ```
-github "rootstrap/RSSwiftNetworking" ~> 1.0.0
+github "rootstrap/RSSwiftNetworking" ~> 1.1.0
 ```
 
 #### 3. Swift Package Manager

--- a/RSSwiftNetworking.podspec
+++ b/RSSwiftNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RSSwiftNetworking'
-  s.version          = '1.0.1'
+  s.version          = '1.1.0'
   s.summary          = 'A flexible network layer API written in Swift.'
 
   s.description      = 'A flexible network layer API written in Swift. Compatible with iOS, iPadOS and tvOS.'

--- a/Sources/RSSwiftNetworking/Protocols/APIClient.swift
+++ b/Sources/RSSwiftNetworking/Protocols/APIClient.swift
@@ -8,11 +8,11 @@ public typealias CompletionCallback<T: Decodable> = (
 /// Defines the requirement for an API Client object
 public protocol APIClient {
 
-  /// Returns the base encoding configration for all requests parameters.
+  /// Returns the base encoding configuration for all requests parameters.
   /// Will be overriden by the `Endpoint` encoding configuration, if any.
   var encodingConfiguration: EncodingConfiguration { get }
 
-  /// Returns the base decoding configration for all request reponses.
+  /// Returns the base decoding configuration for all request reponses.
   /// Will be overriden by the `Endpoint` decoding configuration, if any.
   var decodingConfiguration: DecodingConfiguration { get }
 

--- a/Sources/RSSwiftNetworking/Types/API/APIEndpoint.swift
+++ b/Sources/RSSwiftNetworking/Types/API/APIEndpoint.swift
@@ -31,4 +31,8 @@ public struct APIEndpoint: Endpoint {
     endpoint.decodingConfiguration
   }
 
+  public var parameterEncoding: ParameterEncoding {
+      endpoint.parameterEncoding
+  }
+
 }

--- a/Sources/RSSwiftNetworking/Types/API/Endpoint.swift
+++ b/Sources/RSSwiftNetworking/Types/API/Endpoint.swift
@@ -13,6 +13,7 @@ public protocol Endpoint {
   var headers: [String: String] { get }
   var parameters: [String: Any] { get }
   var decodingConfiguration: DecodingConfiguration? { get }
+  var parameterEncoding: ParameterEncoding { get }
 
 }
 
@@ -30,6 +31,15 @@ public extension Endpoint {
 
   var headers: [String: String] {
     [:]
+  }
+
+  var parameterEncoding: ParameterEncoding {
+    switch method {
+    case .patch, .put, .post:
+        return .httpBody(.json)
+    default:
+      return .urlQuery
+    }
   }
 
 }

--- a/Sources/RSSwiftNetworking/Types/API/ParameterEncoding.swift
+++ b/Sources/RSSwiftNetworking/Types/API/ParameterEncoding.swift
@@ -1,0 +1,25 @@
+//
+//  ParameterEncoding.swift
+//  RSSwiftNetworking
+//
+//  Created by German on 30/8/22.
+//
+
+import Foundation
+
+/// The different ways to encode HTTP request paramenters
+public enum ParameterEncoding {
+    /// The parameters are encoded in the HTTP request body.
+    case httpBody(HTTPBodyEncoding)
+
+    /// The parameters are encoded in a query string into the request URL.
+    case urlQuery
+}
+
+/// The formats available for the parameters encoded in the HTTP request body
+public enum HTTPBodyEncoding {
+    /// The parameters are sent in JSON format.
+    case json
+    /// The parameters are sent as-is, encoded in a Data object.
+    case plain
+}

--- a/Sources/RSSwiftNetworkingAlamofire/AlamofireNetworkProvider.swift
+++ b/Sources/RSSwiftNetworkingAlamofire/AlamofireNetworkProvider.swift
@@ -17,6 +17,7 @@ public final class AlamofireNetworkProvider: NetworkProvider {
       endpoint.requestURL,
       method: endpoint.method.alamofireMethod,
       parameters: endpoint.parameters,
+      encoding: endpoint.parameterEncoding.alamofireEncoding,
       headers: headers
     )
     .validate()
@@ -146,4 +147,18 @@ fileprivate extension MultipartMedia {
   func embed(inForm multipart: MultipartFormData) {
     multipart.append(data, withName: key, fileName: toFile, mimeType: type.rawValue)
   }
+}
+
+fileprivate extension RSSwiftNetworking.ParameterEncoding {
+    var alamofireEncoding: Alamofire.ParameterEncoding {
+        switch self {
+        case .httpBody(let format):
+            if format == .json {
+                return JSONEncoding.default
+            }
+            return URLEncoding(destination: .httpBody)
+        case .urlQuery:
+            return URLEncoding(destination: .queryString)
+        }
+    }
 }


### PR DESCRIPTION
Fixes #4 

The `Endpoint` protocol now supports configuration for the desired `ParameterEncoding`.
As a convenience default implementation, the API specifies http body encoding for POST, PATCH and PUT requests, while encoding parameters in the URL query string for other HTTP methods.
