### PR TITLE
Swift Concurrency support v1.1.1

### DIFF
--- a/Example/RSSwiftNetworking.xcodeproj/project.pbxproj
+++ b/Example/RSSwiftNetworking.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -403,6 +404,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Example/RSSwiftNetworking/ViewController.swift
+++ b/Example/RSSwiftNetworking/ViewController.swift
@@ -68,10 +68,11 @@ class ViewController: UIViewController {
     makeRequestButton.isEnabled = false
     let apiClient = BaseAPIClient.alamofire
     let mockEndpoint = MockJSONAPIEndpoint(url: url)
-    apiClient.request(endpoint: mockEndpoint) { [weak self] (result: Result<Network.EmptyResponse?, Error>, responseHeaders) in
-      self?.makeRequestButton.isEnabled = true
 
-      switch result {
+    Task { [weak self] in
+      let response: RequestResponse<Network.EmptyResponse?> = await apiClient.request(endpoint: mockEndpoint)
+
+      switch response.result {
       case .success:
         self?.showAlertMessage(success: true)
       case .failure(let error):

--- a/Package.swift
+++ b/Package.swift
@@ -1,18 +1,17 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
   name: "RSSwiftNetworking",
-  platforms: [.iOS(.v12), .tvOS(.v10), .macOS(.v11)],
+  platforms: [.iOS(.v13), .tvOS(.v15), .macOS(.v12)],
   products: [
     .library(name: "RSSwiftNetworking", targets: ["RSSwiftNetworking"]),
     .library(name: "RSSwiftNetworkingAlamofire", targets: ["RSSwiftNetworkingAlamofire", "RSSwiftNetworking"])
   ],
   dependencies: [
     .package(
-        name: "Alamofire",
         url: "https://github.com/Alamofire/Alamofire.git",
         from: "5.2.0"
     ),

--- a/RSSwiftNetworking.podspec
+++ b/RSSwiftNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RSSwiftNetworking'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'A flexible network layer API written in Swift.'
 
   s.description      = 'A flexible network layer API written in Swift. Compatible with iOS, iPadOS and tvOS.'
@@ -13,11 +13,11 @@ Pod::Spec.new do |s|
                        }
   s.social_media_url = 'https://www.rootstrap.com/'
   
-  s.ios.deployment_target = '14.0'
-  s.osx.deployment_target = '11.0'
-  s.tvos.deployment_target = '10.0'
+  s.ios.deployment_target = '15.0'
+  s.osx.deployment_target = '12.0'
+  s.tvos.deployment_target = '15.0'
 
-  s.swift_version = '5.2'
+  s.swift_version = '5.5'
 
   s.default_subspec = 'Core'
   s.subspec 'Core' do |core_spec|

--- a/Sources/RSSwiftNetworking/Extensions/APIClient+Concurrency.swift
+++ b/Sources/RSSwiftNetworking/Extensions/APIClient+Concurrency.swift
@@ -1,0 +1,37 @@
+public typealias RequestResponse<T: Decodable> = (
+  result: Result<T?, Error>,
+  responseHeaders: [AnyHashable: Any]
+)
+
+public extension APIClient {
+
+    @discardableResult
+    func request<T: Decodable>(endpoint: Endpoint) async -> RequestResponse<T> {
+        await withCheckedContinuation { continuation in
+            self.request(endpoint: endpoint) { result, responseHeaders in
+                continuation.resume(returning: (result, responseHeaders))
+            }
+        }
+    }
+
+    /// Asynchronously performs a multipart request to upload one or many `MultipartMedia` objects.
+    /// The endpoint parameters will be encoded in the multipart form.
+    /// Note: Multipart requests do not support `Content-Type = application/json` headers.
+    /// If your API requires this header user base64 uploads instead.
+    @discardableResult
+    func multipartRequest<T: Decodable>(
+      endpoint: Endpoint,
+      paramsRootKey: String,
+      media: [MultipartMedia]
+    ) async -> RequestResponse<T> {
+        await withCheckedContinuation { continuation in
+            multipartRequest(
+                endpoint: endpoint,
+                paramsRootKey: paramsRootKey,
+                media: media
+            ) { result, responseHeaders in
+                continuation.resume(returning: (result, responseHeaders))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3 

The framework continues to work with the original closure-based functions. The Concurrency framework support was added on top of it.