### PR TITLE
Separate key name from fileName on MimeType 

### DIFF
--- a/Sources/RSSwiftNetworking/Extensions/Data+Base64.swift
+++ b/Sources/RSSwiftNetworking/Extensions/Data+Base64.swift
@@ -11,6 +11,6 @@ import Foundation
 // Helper to retrieve the right string value for base64 API uploaders
 public extension Data {
   func asBase64Param(withType type: MimeType = .jpeg) -> String {
-    "data:\(type.rawValue);base64,\(self.base64EncodedString())"
+    "data:\(type.contentType);base64,\(self.base64EncodedString())"
   }
 }

--- a/Sources/RSSwiftNetworking/Models/Base64Media.swift
+++ b/Sources/RSSwiftNetworking/Models/Base64Media.swift
@@ -11,8 +11,8 @@ import Foundation
 public class Base64Media: MultipartMedia {
   var base64: String
   
-  override init(key: String, data: Data, type: MimeType = .jpeg) {
+  override public init(fileName: String, key: String, data: Data, type: MimeType = .jpeg) {
     self.base64 = data.asBase64Param(withType: type)
-    super.init(key: key, data: data, type: type)
+    super.init(fileName: fileName, key: key, data: data, type: type)
   }
 }

--- a/Sources/RSSwiftNetworking/Models/MultipartMedia.swift
+++ b/Sources/RSSwiftNetworking/Models/MultipartMedia.swift
@@ -9,45 +9,73 @@
 import Foundation
 
 // Basic media MIME types, add more if needed.
-public enum MimeType: String {
-  case jpeg = "image/jpeg"
-  case bmp = "image/bmp"
-  case png = "image/png"
+public enum MimeType {
+  case jpeg
+  case bmp
+  case png
+  case mov
+  case mpeg
+  case avi
+  case json
+  case custom(contentType: String, extension: String)
   
-  case mov = "video/quicktime"
-  case mpeg = "video/mpeg"
-  case avi = "video/avi"
-  case json = "application/json"
-  
-  case usd, usdz = "application/octet-stream"
-  
-  func fileExtension() -> String {
+  public var contentType: String {
     switch self {
-    case .bmp: return ".bmp"
-    case .png: return ".png"
-    case .mov: return ".mov"
-    case .mpeg: return ".mpeg"
-    case .avi: return ".avi"
-    case .json: return ".json"
-    case .usd: return ".usd"
-    case .usdz: return ".usdz"
-    default: return ".jpg"
+    case .jpeg:
+      return "image/jpeg"
+    case .bmp:
+      return "image/bmp"
+    case .png:
+      return "image/png"
+    case .mov:
+      return "video/quicktime"
+    case .mpeg:
+      return "video/mpeg"
+    case .avi:
+      return "video/avi"
+    case .json:
+      return "application/json"
+    case .custom(let contentType, _):
+      return contentType
+    }
+  }
+  
+  public var fileExtension: String {
+    switch self {
+    case .jpeg:
+      return ".jpg"
+    case .bmp:
+      return ".bmp"
+    case .png:
+      return ".png"
+    case .mov:
+      return ".mov"
+    case .mpeg:
+      return ".mpeg"
+    case .avi:
+      return ".avi"
+    case .json:
+      return ".json"
+    case .custom( _, let fileExtension):
+      return fileExtension
     }
   }
 }
 
 public class MultipartMedia {
-  public var key: String
+  public var key: String // key name to send file
+  public var fileName: String // file name
   public var data: Data
   public var type: MimeType
 
   public var toFile: String {
-    key.validFilename + type.fileExtension()
+    fileName.validFilename + type.fileExtension
   }
   
-  public init(key: String, data: Data, type: MimeType = .jpeg) {
+  public init(fileName: String, key: String, data: Data, type: MimeType = .jpeg) {
     self.key = key
     self.data = data
     self.type = type
+    self.fileName = fileName
   }
 }

--- a/Sources/RSSwiftNetworkingAlamofire/AlamofireNetworkProvider.swift
+++ b/Sources/RSSwiftNetworkingAlamofire/AlamofireNetworkProvider.swift
@@ -145,7 +145,7 @@ extension DataRequest: Cancellable {}
 
 fileprivate extension MultipartMedia {
   func embed(inForm multipart: MultipartFormData) {
-    multipart.append(data, withName: key, fileName: toFile, mimeType: type.rawValue)
+    multipart.append(data, withName: key, fileName: toFile, mimeType: type.contentType)
   }
 }
 


### PR DESCRIPTION
### Description

The MimeType enum was using the same name for the key (used to send the file to the backend) and the fileName. As a result, if a backend requirement is to submit the multipart with the key `file` and we were naming the file as `example.jpg`, the key was also being named `example`. Consequently, the API endpoint always returned a `bad request` response

The structure of the MimeType was changed to provide us with the ability to add any other custom mimeType that we may need in the future